### PR TITLE
Fix symlink to Pods-acknowledgements.plist

### DIFF
--- a/Pods-acknowledgements.plist
+++ b/Pods-acknowledgements.plist
@@ -1,1 +1,1 @@
-../Pods-acknowledgements.plist
+../Target Support Files/Pods/Pods-acknowledgements.plist


### PR DESCRIPTION
Currently one can't use this pod because it breaks the build of app. The problem is that the simlink to `Pods-acknowledgements.plist` is broken. (I think CocoaPods' inner folder hierarchy has changed in the meantime.) This PR fixes that.

However it seems that the pod does not pass the `pod lib lint` check since there is no Pods-acknowledgements.plist yet so the simlink is broken (independently from this PR). Maybe earlier it wasn't an error if your pod contained a broken simlink.

So I'm not sure that you can update the pod but I hope. :)
